### PR TITLE
Update reagent, cljs, other deps. Version bump.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # cljs-pikaday
 
-`cljs-pikaday` is intended to provide a native ClojureScript interface to the 
-[Pikaday](https://github.com/dbushell/Pikaday) JavaScript date picker, intended 
+`cljs-pikaday` is intended to provide a native ClojureScript interface to the
+[Pikaday](https://github.com/dbushell/Pikaday) JavaScript date picker, intended
 for use in the various ClojureScript react frameworks.
 
-The implementation currently works for 
-[reagent](https://github.com/reagent-project/reagent) (I'm hoping to add an 
-[Om]() implementation soon, and maybe a nicer interface for 
+The implementation currently works for
+[reagent](https://github.com/reagent-project/reagent) (I'm hoping to add an
+[Om]() implementation soon, and maybe a nicer interface for
 [re-frame](https://github.com/Day8/re-frame)).
 
-`cljs-pikaday` currently uses plain JavaScript `Date` objects for 
-its values - I'd like to have it able to use cljs-time and/or 
+`cljs-pikaday` currently uses plain JavaScript `Date` objects for
+its values - I'd like to have it able to use cljs-time and/or
 moment at some point, because ugh, JavaScript `Date` objects.
 
 ## Installation
 
-Add `[cljs-pikaday "0.1.2"]` to your project's `:dependencies` vector:
+Add `[cljs-pikaday "0.1.3"]` to your project's `:dependencies` vector:
 
 [![Clojars Project](http://clojars.org/cljs-pikaday/latest-version.svg)](http://clojars.org/cljs-pikaday)
 
 ## reagent interface
 
-The reagent implementation accepts an ratom 
+The reagent implementation accepts an ratom
 (or [reaction](https://github.com/Day8/re-frame#how-flow-happens-in-reagent))
-as its input. When the user selects a new date, the component will update 
-the atom, and if the atom is updated elsewhere, the date-picker will display 
+as its input. When the user selects a new date, the component will update
+the atom, and if the atom is updated elsewhere, the date-picker will display
 the new date.
 
-There is a more fleshed-out example in the 
+There is a more fleshed-out example in the
 [examples/reagent directory](examples/reagent/), but the simplest way to use
 it would be something like this:
 
@@ -45,20 +45,20 @@ it would be something like this:
 (reagent/render [home-page] (.getElementById js/document "app")))
 ```
 
-`pikaday/date-selector` returns code for an `<input>` tag, and 
-sets up various reagent lifecycle methods to instantiate and bind 
-a `Pikaday` instance. When the user selects a new date in the input 
-field, the atom passed in to the `:date-atom` property will be 
+`pikaday/date-selector` returns code for an `<input>` tag, and
+sets up various reagent lifecycle methods to instantiate and bind
+a `Pikaday` instance. When the user selects a new date in the input
+field, the atom passed in to the `:date-atom` property will be
 `reset!` with its new value.
 
-There is [an example reagent project](examples/reagent/) which demonstrates 
+There is [an example reagent project](examples/reagent/) which demonstrates
 some additional functionality.
 
 ## CSS
 
-Pikaday comes with its own CSS file, which is autoloadable through various 
-javascript packaging tools. If an interface to these exists in ClojureScript 
-I can't find it, so as a workaround it's probably easiest to simplly download 
+Pikaday comes with its own CSS file, which is autoloadable through various
+javascript packaging tools. If an interface to these exists in ClojureScript
+I can't find it, so as a workaround it's probably easiest to simplly download
 the [pikaday.css file from github](https://github.com/dbushell/Pikaday/blob/master/css/pikaday.css)
 and reference it in your HTML.
 

--- a/examples/reagent/env/dev/clj/cljs_pikaday_reagent_example/dev.clj
+++ b/examples/reagent/env/dev/clj/cljs_pikaday_reagent_example/dev.clj
@@ -4,7 +4,7 @@
             [leiningen.core.main :as lein]))
 
 (defn browser-repl []
-  (piggieback/cljs-repl :repl-env (weasel/repl-env :ip "127.0.0.1" :port 9001)))
+  (piggieback/cljs-repl (weasel/repl-env :ip "127.0.0.1" :port 9001)))
 
 (defn start-figwheel []
   (future

--- a/examples/reagent/project.clj
+++ b/examples/reagent/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-pikaday-reagent-example "0.1.0-SNAPSHOT"
+(defproject cljs-pikaday-reagent-example "0.2.0-SNAPSHOT"
   :description "reagent example project for cljs-pikaday"
   :url "https://github.com/timgilbert/cljs-pikaday"
   :license {:name "MIT"
@@ -6,28 +6,28 @@
 
   :source-paths ["src/clj" "../../src/cljs" "src/cljs"]
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [ring-server "0.4.0"]
-                 [cljsjs/react "0.13.1-0"]
-                 [reagent "0.5.0"]
-                 [reagent-forms "0.4.9"]
-                 [reagent-utils "0.1.4"]
-                 [org.clojure/clojurescript "0.0-3169" :scope "provided"]
-                 [ring "1.3.2"]
-                 [ring/ring-defaults "0.1.4"]
-                 [prone "0.8.1"]
-                 [compojure "1.3.3"]
-                 [selmer "0.8.2"]
-                 [environ "1.0.0"]
-                 [secretary "1.2.2"]
-                 [cljsjs/pikaday "1.3.2-0"]
-                 [camel-snake-kebab "0.3.1" :exclusions [org.clojure/clojure]]
-                 [shodan "0.4.1"]]
+                 [cljsjs/react "15.2.1-1"]
+                 [reagent "0.6.0-rc"]
+                 [reagent-forms "0.5.24"]
+                 [reagent-utils "0.1.9"]
+                 [org.clojure/clojurescript "1.9.93" :scope "provided"]
+                 [ring "1.5.0"]
+                 [ring/ring-defaults "0.2.1"]
+                 [prone "1.1.1"]
+                 [compojure "1.5.1"]
+                 [selmer "1.0.7"]
+                 [environ "1.0.3"]
+                 [secretary "1.2.3"]
+                 [cljsjs/pikaday "1.4.0-1"]
+                 [camel-snake-kebab "0.4.0" :exclusions [org.clojure/clojure]]
+                 [shodan "0.4.2"]]
 
-  :plugins [[lein-cljsbuild "1.0.4"]
-            [lein-environ "1.0.0"]
-            [lein-ring "0.9.1"]
-            [lein-asset-minifier "0.2.2"]]
+  :plugins [[lein-cljsbuild "1.1.3"]
+            [lein-environ "1.0.3"]
+            [lein-ring "0.9.7"]
+            [lein-asset-minifier "0.3.0"]]
 
   :ring {:handler cljs-pikaday-reagent-example.handler/app
          :uberwar-name "cljs-pikaday-reagent-example.war"}
@@ -59,17 +59,17 @@
   :profiles {:dev {:repl-options {:init-ns cljs-pikaday-reagent-example.repl
                                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
 
-                   :dependencies [[ring-mock "0.1.5"]
-                                  [ring/ring-devel "1.3.2"]
-                                  [leiningen "2.5.1"]
-                                  [figwheel "0.2.5"]
-                                  [weasel "0.6.0"]
-                                  [com.cemerick/piggieback "0.2.0"]
-                                  [org.clojure/tools.nrepl "0.2.10"]
-                                  [pjstadig/humane-test-output "0.7.0"]]
+                   :dependencies [[ring/ring-mock "0.3.0"]
+                                  [ring/ring-devel "1.5.0"]
+                                  [leiningen "2.6.1"]
+                                  [figwheel "0.5.4-7"]
+                                  [weasel "0.7.0" :exclusions [org.clojure/clojurescript]]
+                                  [com.cemerick/piggieback "0.2.1"]
+                                  [org.clojure/tools.nrepl "0.2.12"]
+                                  [pjstadig/humane-test-output "0.8.0"]]
 
                    :source-paths ["env/dev/clj"]
-                   :plugins [[lein-figwheel "0.2.3-SNAPSHOT"]]
+                   :plugins [[lein-figwheel "0.5.4-7"]]
 
                    :injections [(require 'pjstadig.humane-test-output)
                                 (pjstadig.humane-test-output/activate!)]
@@ -83,9 +83,7 @@
 
                    :cljsbuild {:builds {:app {:source-paths ["env/dev/cljs"]
                                               :compiler {:main "cljs-pikaday-reagent-example.dev"
-                                                         :source-map true}}
-}
-}}
+                                                         :source-map true}}}}}
 
              :uberjar {:hooks [leiningen.cljsbuild minify-assets.plugin/hooks]
                        :env {:production true}

--- a/examples/reagent/src/cljs/cljs_pikaday_reagent_example/core.cljs
+++ b/examples/reagent/src/cljs/cljs_pikaday_reagent_example/core.cljs
@@ -68,11 +68,11 @@
          :pikaday-attrs {:max-date today}
          :input-attrs {:id "end"}}]]
     [:div
-      [:p "Your selected range: " (get-date! :start) " to " (get-date! :end)]
-      [:p "Days selected: " @total-days-selected]
-      [:p [:button {:on-click #(set-date! :start today)} "Start today"]
-      [:p [:button {:on-click #(set-date! :start last-week)} "Start last week"]
-      [:p [:button {:on-click #(do (set-date! :start nil) (set-date! :end nil))} "Unset both"]]]]]
+     [:p "Your selected range: " (get-date! :start) " to " (get-date! :end)]
+     [:p "Days selected: " @total-days-selected]
+     [:p [:button {:on-click #(set-date! :start today)} "Start today"]]
+     [:p [:button {:on-click #(set-date! :start last-week)} "Start last week"]]
+     [:p [:button {:on-click #(do (set-date! :start nil) (set-date! :end nil))} "Unset both"]]]
     [:div [:p "This is a demonstration page for the "
               [:a {:href "https://github.com/timgilbert/cljs-pikaday"} "cljs-pikaday"] " library."]]])
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cljs-pikaday "0.1.2"
+(defproject cljs-pikaday "0.1.3"
   :description "ClojureScript interface to the Pikaday JS date picker"
   :url "https://github.com/timgilbert/cljs-pikaday"
   :license {:name "MIT"
@@ -6,8 +6,8 @@
 
   :source-paths ["src"]
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [reagent "0.5.0"]
-                 [org.clojure/clojurescript "0.0-3169" :scope "provided"]
-                 [cljsjs/pikaday "1.3.2-0"]
-                 [camel-snake-kebab "0.3.1" :exclusions [org.clojure/clojure]]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [reagent "0.6.0-rc"]
+                 [org.clojure/clojurescript "1.9.93" :scope "provided"]
+                 [cljsjs/pikaday "1.4.0-1"]
+                 [camel-snake-kebab "0.4.0" :exclusions [org.clojure/clojure]]])

--- a/src/cljs_pikaday/reagent.cljs
+++ b/src/cljs_pikaday/reagent.cljs
@@ -26,7 +26,7 @@
       {:component-did-mount
         (fn [this]
           (let [default-opts
-                {:field (.getDOMNode this)
+                {:field (js/ReactDOM.findDOMNode this)
                  :default-date @date-atom
                  :set-default-date true
                  :on-select #(when date-atom (reset! date-atom %))}
@@ -62,5 +62,5 @@
          (reset! instance-atom nil))
        :display-name "pikaday-component"
        :reagent-render
-        (fn [input-attrs]
-          [:input input-attrs])})))
+       (fn [props]
+         [:input (:input-attrs props)])})))


### PR DESCRIPTION
Hi, this makes some minor changes to work with `reagent 0.6.0-rc`.
Also updates most dependencies including `cljsjs/pikaday 1.4.0-1`. 
I went ahead and updated the example and readme as well, seems to work well.
